### PR TITLE
Use podman on worker nodes

### DIFF
--- a/ocp4ocs4/ocs4.adoc
+++ b/ocp4ocs4/ocs4.adoc
@@ -752,11 +752,6 @@ uploaded files.
 
 In this section the `ocs-storagecluster-cephfs` *Storage Class* will be used to create a RWX (ReadWriteMany) PVC that can be used by multiple pods at the same time. As an example we will be running a highly-available container image registry. The persistent storage will be based on a CephFS volume in the Ceph pool `ocs-storagecluster-cephfilesystem-data0`.
 
-[CAUTION]
-====
-*This section requires either installing or downloading podman. The utility podman is known to not operator correctly with Mac OS.*
-====
-
 Deploy the registry like this:
 
 [source,role="execute"]
@@ -832,32 +827,39 @@ NAME            HOST/PORT                                                       
 kube-registry   kube-registry-kube-system.apps.cluster-berlin-fc41.berlin-fc41.example.opentlc.com          kube-registry   <all>   edge          None
 ----
 
-To continue you will need to install Podman. Installation steps for various operating systems can be found here: https://github.com/containers/libpod/blob/master/install.md
+To use the new registry, we will connect to one of our worker hosts via `oc debug` and use the already installed podman binary
 
-For RHEL-based systems, it is as easy as:
+.Connect to one of the workers shell
+[source,role="execute"]
+----
+oc debug $(oc get nodes -l node-role.kubernetes.io/worker -o name | head -n1)
+----
+
+.Enable the host binaries
+[source,role="execute"]
+----
+chroot /host
+----
+
+Now that we have access to podman, we can download the alpine container image as an example and upload it to our new registry:
 
 [source,role="execute"]
 ----
-sudo yum -y install podman
-----
-
-Now that podman is installed we can now download the alpine container image as an example and upload it to our new registry:
-
-[source,role="execute"]
-----
-sudo podman pull docker.io/library/alpine
+podman pull docker.io/library/alpine
 ----
 
 [source,role="edit"]
 ----
-sudo podman push docker.io/library/alpine --tls-verify=false <KUBE_REGISTRY_ROUTE>/alpine
+podman push docker.io/library/alpine --tls-verify=false <KUBE_REGISTRY_ROUTE>/alpine
 ----
 .Example command:
 ----
-sudo podman push docker.io/library/alpine --tls-verify=false kube-registry-kube-system.apps.cluster-ocs-3ed9.ocs-3ed9.example.opentlc.com/alpine
+podman push docker.io/library/alpine --tls-verify=false kube-registry-kube-system.apps.cluster-ocs-3ed9.ocs-3ed9.example.opentlc.com/alpine
 ----
 
 CAUTION: Make sure to replace the URL in the push command with the URL of your route
+
+Now exit the debug session on the host by either pressing kbd:[Ctrl+D] twice or executing `exit` twice. Afterwards you should be back on your workstation.
 
 Next we use the `toolbox` *Pod* to check on our underlying CephFS volume:
 

--- a/ocp4ocs4/ocs4.adoc
+++ b/ocp4ocs4/ocs4.adoc
@@ -859,7 +859,7 @@ podman push docker.io/library/alpine --tls-verify=false kube-registry-kube-syste
 
 CAUTION: Make sure to replace the URL in the push command with the URL of your route
 
-Now exit the debug session on the host by either pressing kbd:[Ctrl+D] twice or executing `exit` twice. Afterwards you should be back on your workstation.
+Now exit the debug session on the host by either pressing kbd:[Ctrl+D] twice or executing `exit` twice to get back to your workstation shell.
 
 Next we use the `toolbox` *Pod* to check on our underlying CephFS volume:
 


### PR DESCRIPTION
Remove install instructions for Podman, this section did not work on MacOS before...
Instead we will work directly on one of the workers

Resolves #94