### PR TITLE
Remove Default Storage class change and update RBD based PVC example

### DIFF
--- a/ocp4ocs4/configurable-rails-app.yaml
+++ b/ocp4ocs4/configurable-rails-app.yaml
@@ -1,0 +1,400 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  app: rails-pgsql-persistent-storageclass
+  template: rails-pgsql-persistent-storageclass
+message: |-
+  The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.
+
+  For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.
+metadata:
+  annotations:
+    description: An example Rails application with a PostgreSQL database. For more
+      information about using this template, including OpenShift considerations, see
+      https://github.com/sclorg/rails-ex/blob/master/README.md.
+    iconClass: icon-ruby
+    openshift.io/display-name: Rails + PostgreSQL + Congigigurable StorageClass
+    openshift.io/documentation-url: https://github.com/sclorg/rails-ex
+    openshift.io/long-description: This template defines resources needed to develop
+      a Rails application, including a build configuration, application deployment
+      configuration, and database deployment configuration.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    openshift.io/support-url: https://access.redhat.com
+    samples.operator.openshift.io/version: 4.2.4
+    tags: quickstart,ruby,rails
+    template.openshift.io/bindable: "false"
+  labels:
+    samples.operator.openshift.io/managed: "true"
+  name: rails-pgsql-persistent-storageclass
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${NAME}
+  stringData:
+    application-password: ${APPLICATION_PASSWORD}
+    application-user: ${APPLICATION_USER}
+    database-password: ${DATABASE_PASSWORD}
+    database-user: ${DATABASE_USER}
+    keybase: ${SECRET_KEY_BASE}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes and load balances the application pods
+      service.alpha.openshift.io/dependencies: '[{"name": "${DATABASE_SERVICE_NAME}",
+        "kind": "Service"}]'
+    name: ${NAME}
+  spec:
+    ports:
+    - name: web
+      port: 8080
+      targetPort: 8080
+    selector:
+      name: ${NAME}
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: ${NAME}
+  spec:
+    host: ${APPLICATION_DOMAIN}
+    to:
+      kind: Service
+      name: ${NAME}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      description: Keeps track of changes in the application image
+    name: ${NAME}
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+      description: Defines how to build the application
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${NAME}
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${NAME}:latest
+    postCommit:
+      script: bundle exec rake test
+    source:
+      contextDir: ${CONTEXT_DIR}
+      git:
+        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${SOURCE_REPOSITORY_URL}
+      type: Git
+    strategy:
+      sourceStrategy:
+        env:
+        - name: RUBYGEM_MIRROR
+          value: ${RUBYGEM_MIRROR}
+        from:
+          kind: ImageStreamTag
+          name: ruby:2.5
+          namespace: ${NAMESPACE}
+      type: Source
+    triggers:
+    - type: ImageChange
+    - type: ConfigChange
+    - github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+      type: GitHub
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Defines how to deploy the application server
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${NAME}
+    strategy:
+      recreateParams:
+        pre:
+          execNewPod:
+            command:
+            - ./migrate-database.sh
+            containerName: ${NAME}
+          failurePolicy: Abort
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${NAME}
+        name: ${NAME}
+      spec:
+        containers:
+        - env:
+          - name: DATABASE_SERVICE_NAME
+            value: ${DATABASE_SERVICE_NAME}
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: ${NAME}
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: ${NAME}
+          - name: SECRET_KEY_BASE
+            valueFrom:
+              secretKeyRef:
+                key: keybase
+                name: ${NAME}
+          - name: POSTGRESQL_DATABASE
+            value: ${DATABASE_NAME}
+          - name: POSTGRESQL_MAX_CONNECTIONS
+            value: ${POSTGRESQL_MAX_CONNECTIONS}
+          - name: POSTGRESQL_SHARED_BUFFERS
+            value: ${POSTGRESQL_SHARED_BUFFERS}
+          - name: APPLICATION_DOMAIN
+            value: ${APPLICATION_DOMAIN}
+          - name: APPLICATION_USER
+            valueFrom:
+              secretKeyRef:
+                key: application-user
+                name: ${NAME}
+          - name: APPLICATION_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: application-password
+                name: ${NAME}
+          - name: RAILS_ENV
+            value: ${RAILS_ENV}
+          image: ' '
+          livenessProbe:
+            httpGet:
+              path: /articles
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+          name: ${NAME}
+          ports:
+          - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /articles
+              port: 8080
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${NAME}
+        from:
+          kind: ImageStreamTag
+          name: ${NAME}:latest
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    storageClassName: ${STORAGE_CLASS}
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes the database server
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Defines how to deploy the database
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${DATABASE_SERVICE_NAME}
+        name: ${DATABASE_SERVICE_NAME}
+      spec:
+        containers:
+        - env:
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: ${NAME}
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: ${NAME}
+          - name: POSTGRESQL_DATABASE
+            value: ${DATABASE_NAME}
+          - name: POSTGRESQL_MAX_CONNECTIONS
+            value: ${POSTGRESQL_MAX_CONNECTIONS}
+          - name: POSTGRESQL_SHARED_BUFFERS
+            value: ${POSTGRESQL_SHARED_BUFFERS}
+          image: ' '
+          livenessProbe:
+            exec:
+              command:
+              - /usr/libexec/check-container
+              - --live
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+          name: postgresql
+          ports:
+          - containerPort: 5432
+          readinessProbe:
+            exec:
+              command:
+              - /usr/libexec/check-container
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: ${MEMORY_POSTGRESQL_LIMIT}
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: ${DATABASE_SERVICE_NAME}-data
+        volumes:
+        - name: ${DATABASE_SERVICE_NAME}-data
+          persistentVolumeClaim:
+            claimName: ${DATABASE_SERVICE_NAME}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - postgresql
+        from:
+          kind: ImageStreamTag
+          name: postgresql:10
+          namespace: ${NAMESPACE}
+      type: ImageChange
+    - type: ConfigChange
+parameters:
+- description: The name assigned to all of the frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: rails-pgsql-persistent
+- description: The OpenShift Namespace where the ImageStream resides.
+  displayName: Namespace
+  name: NAMESPACE
+  required: true
+  value: openshift
+- description: Maximum amount of memory the Rails container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- description: Maximum amount of memory the PostgreSQL container can use.
+  displayName: Memory Limit (PostgreSQL)
+  name: MEMORY_POSTGRESQL_LIMIT
+  required: true
+  value: 512Mi
+- description: Volume space available for data, e.g. 512Mi, 2Gi
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 1Gi
+- description: Storage Class used to provision Persistent Volume
+  displayName: Volume Storage Class
+  name: STORAGE_CLASS
+  required: true
+  value: gp2
+- description: The URL of the repository with your application source code.
+  displayName: Git Repository URL
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/sclorg/rails-ex.git
+- description: Set this to a branch name, tag or other ref of your repository if you
+    are not using the default branch.
+  displayName: Git Reference
+  name: SOURCE_REPOSITORY_REF
+- description: Set this to the relative path to your project if it is not in the root
+    of your repository.
+  displayName: Context Directory
+  name: CONTEXT_DIR
+- description: The exposed hostname that will route to the Rails service, if left
+    blank a value will be defaulted.
+  displayName: Application Hostname
+  name: APPLICATION_DOMAIN
+- description: Github trigger secret.  A difficult to guess string encoded as part
+    of the webhook URL.  Not encrypted.
+  displayName: GitHub Webhook Secret
+  from: '[a-zA-Z0-9]{40}'
+  generate: expression
+  name: GITHUB_WEBHOOK_SECRET
+- description: Your secret key for verifying the integrity of signed cookies.
+  displayName: Secret Key
+  from: '[a-z0-9]{127}'
+  generate: expression
+  name: SECRET_KEY_BASE
+- description: The application user that is used within the sample application to
+    authorize access on pages.
+  displayName: Application Username
+  name: APPLICATION_USER
+  required: true
+  value: openshift
+- description: The application password that is used within the sample application
+    to authorize access on pages.
+  displayName: Application Password
+  name: APPLICATION_PASSWORD
+  required: true
+  value: secret
+- description: Environment under which the sample application will run. Could be set
+    to production, development or test.
+  displayName: Rails Environment
+  name: RAILS_ENV
+  required: true
+  value: production
+- displayName: Database Service Name
+  name: DATABASE_SERVICE_NAME
+  required: true
+  value: postgresql
+- displayName: Database Username
+  from: user[A-Z0-9]{3}
+  generate: expression
+  name: DATABASE_USER
+- displayName: Database Password
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: DATABASE_PASSWORD
+- displayName: Database Name
+  name: DATABASE_NAME
+  required: true
+  value: root
+- displayName: Maximum Database Connections
+  name: POSTGRESQL_MAX_CONNECTIONS
+  value: "100"
+- displayName: Shared Buffer Amount
+  name: POSTGRESQL_SHARED_BUFFERS
+  value: 12MB
+- description: The custom RubyGems mirror URL
+  displayName: Custom RubyGems Mirror URL
+  name: RUBYGEM_MIRROR

--- a/ocp4ocs4/ocs4.adoc
+++ b/ocp4ocs4/ocs4.adoc
@@ -1650,12 +1650,6 @@ The above commands will always pull the latest noobaa version, so your version m
 ====
 
 [appendix]
-<<<<<<< HEAD
-== Ceph 101 - Introduction to Ceph
-
-This section will go through some Ceph fundamental knowledge for a better understanding of the underlying storage solution
-underneath OCS 4.
-=======
 == Introduction to Ceph
 
 This section will go through Ceph fundamental knowledge for a better understanding of the underlying storage solution
@@ -1665,26 +1659,17 @@ used by OCS 4.
 ====
 The content in this Appendix is relevant to learning about the critical components of Ceph and how Ceph works. OCS 4 uses Ceph in a prescribed manner for providing storage to OpenShift applications. Using *Operators* and *CustomResourceDefinitions* (CRDs) for deploying and managing OCS 4 may restrict some of Ceph's advanced features when compared to general use outside of OCP 4.
 ====
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 [.lead]
 *Timeline*
 
-<<<<<<< HEAD
-The Ceph project has a long history behind it and is not as young as ones may think.
-=======
 The Ceph project has a long history as you can see in the timeline below.
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 .Ceph Project History
 image::imgs/ceph101-timeline.png[Ceph Project Timeline]
 
 [.lead]
-<<<<<<< HEAD
-It is a battle-tested software defined storage solution that has been available as a storage backend with Openstack and Kubernetes for quite some time.
-=======
 It is a battle-tested software defined storage (SDS) solution that has been available as a storage backend for OpenStack and Kubernetes for quite some time.
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 [.lead]
 *Architecture*
@@ -1736,20 +1721,12 @@ are:
 .*_MDSs_*
 The Meta Data Servers manage the metadata for the POSIX compliant shared filesystem such as the directory hierarchy and the file metadata (ownership, timestamps, mode, ...).
 All the metadata is stored with RADOS and they do not server any data to the clients. MDSs are only deployed when a shared filesystem is configured in the Ceph cluster.
-<<<<<<< HEAD
-To avoid
-=======
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 If we look at the Ceph cluster foundation layer, the full picture with the different types of daemons or containers looks like this.
 
 .RADOS as it stands
 image::imgs/ceph101-rados.png[RADOS Overview]
 
-<<<<<<< HEAD
-[.lead]
-=======
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 The circle represent the MONs, the 'M' represent the MGRs and the squares with the bars represent the OSDs. In the diagram above, the cluster operates with
 3 Monitors, 2 Managers and 23 OSDs.
 
@@ -1761,11 +1738,7 @@ Ceph was designed to provides the IT environment with all the necessary access m
 .Different Storage Types Supported
 image::imgs/ceph101-differentstoragetypes.png[Ceph Access Modes]
 
-<<<<<<< HEAD
-Ceph supports block storage through the RADOS Block Device (aka RBD) access method, file storage trhough the Ceph Filesystem (aka CephFS) access method and
-=======
 Ceph supports block storage through the RADOS Block Device (aka RBD) access method, file storage through the Ceph Filesystem (aka CephFS) access method and
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 object storage through its native `librados` API or through the RADOS Gateway (aka RADOSGW or RGW) for compatibility with the S3 and Swift protocols.
 
 [.lead]
@@ -1781,34 +1754,12 @@ The Ceph native API offers different wrappers such as C, C++, Python, Java, Ruby
 [.lead]
 *RADOS Block Device (RBD)*
 
-<<<<<<< HEAD
-This access method is used in Red Hat Enterprise Linux or Openshift 3 and 4. RBDs can be accessed either through a kernel module (RHEL, OCS4)
-or through the 'librbd` API (RHOSP). In the OCP world, RBDs are designed to address the need for RWO PVCs.
-=======
 This access method is used in Red Hat Enterprise Linux or OpenShift version 3.x or 4.x. RBDs can be accessed either through a kernel module (RHEL, OCS4)
 or through the `librbd` API (RHOSP). In the OCP world, RBDs are designed to address the need for RWO PVCs.
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 [.lead]
 *_Kernel Module (kRBD)_*
 
-<<<<<<< HEAD
-.kRBD Diagram
-image::imgs/ceph101-krbd.png[Kernel based RADOS Block Device]
-
-The kernel RBD driver offers superior performance compared to the userspace `librbd` method. However, kRBD is currently limited and does
-not provide the same level of functionality. e.g. no RBD Mirroring support.
-
-[.lead]
-*_Userspace RBD (librbd)_*
-
-.librbd Diagram
-image::imgs/ceph101-librbd.png[Userspace RADOS Block Device]
-
-This access method is used in Red Hat Openstack Environment or in Openshift through the RBD-NBD driver when it lands in RHEL 8.1 kernel.
-This mode allows us to leverage all existing RBD features such as RBD Mirroring.
-
-=======
 The kernel RBD driver offers superior performance compared to the userspace `librbd` method. However, kRBD is currently limited and does
 not provide the same level of functionality. e.g., no RBD Mirroring support.
 
@@ -1824,7 +1775,6 @@ This mode allows us to leverage all existing RBD features such as RBD Mirroring.
 .librbd Diagram
 image::imgs/ceph101-librbd.png[Userspace RADOS Block Device]
 
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 [.lead]
 *_Shared Filesystem (CephFS)_*
 
@@ -1839,21 +1789,6 @@ CephFS is typically used for RWX claims but can also be used to support RWO clai
 [.lead]
 *_Object Storage, S3 and Swift (Ceph RADOS Gateway)_*
 
-<<<<<<< HEAD
-.Amazone S3 or Openstack Swift (Ceph RADOS Gateway)
-image::imgs/ceph101-rgw.png[S3 and Swift Support]
-
-This access method offers support for the Amazon S3 and Openstack Swift support on top of a Ceph cluster. The Openshift Container Storage Multi Cloud
-Gateway can leverage the RADOS Gateway to support Object Bucket Claims. From the Multi Cloud Gateway perspective the RADOS Gateway will be tagged
-as a compatible S3 endpoint.
-
-[.lead]
-*CRUSH*
-
-The Ceph cluster being a distributed architecture, some solution had to be designed to provide an efficient way to distribute the data across the multiple
-OSDs in the cluster. The technique used is called CRUSH or Controlled Replication Under Scalable Hashing. With CRUSH, every object is assigned to one
-and only one hash bucket known as a Placement Group (aka PG).
-=======
 This access method offers support for the Amazon S3 and OpenStack Swift support on top of a Ceph cluster. The Openshift Container Storage Multi Cloud
 Gateway can leverage the RADOS Gateway to support Object Bucket Claims. From the Multi Cloud Gateway perspective the RADOS Gateway will be tagged
 as a compatible S3 endpoint.
@@ -1867,28 +1802,19 @@ image::imgs/ceph101-rgw.png[S3 and Swift Support]
 The Ceph cluster being a distributed architecture some solution had to be designed to provide an efficient way to distribute the data across the multiple
 OSDs in the cluster. The technique used is called CRUSH or Controlled Replication Under Scalable Hashing. With CRUSH, every object is assigned to one
 and only one hash bucket known as a Placement Group (PG).
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 image::imgs/ceph101-crushfromobjecttoosd.png[From Object to OSD]
 
 CRUSH is the central point of configuration for the topology of the cluster. It offers a pseudo-random placement algorithm to distribute the objects across
 the PGs and uses rules to determine the mapping of the PGs to the OSDs. In essence, the PGs are an abstraction layer between the objects (application layer)
-<<<<<<< HEAD
-and the OSDs (physical layer). In case of failure, the PG will be remapped to a different physical devices (OSD) and eventually see its content resynchronized
-=======
 and the OSDs (physical layer). In case of failure, the PGs will be remapped to different physical devices (OSDs) and eventually see their content resynchronized
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 to match the protection rules  selected by the storage administrator.
 
 [.lead]
 *Cluster Partitioning*
 
 The Ceph OSDs will be in charge of the protection of the data as well as the constant checking of the integrity of the data stored in the entire cluster.
-<<<<<<< HEAD
-The cluster will be separated into logical partitions, known as a pool. Each pool has the following properties that can be adjusted:
-=======
 The cluster will be separated into logical partitions, known as pools. Each pool has the following properties that can be adjusted:
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 * An ID (immutable)
 * A name
@@ -1910,11 +1836,7 @@ The diagram above shows the relationship end to end between the object at the ac
 
 [NOTE]
 ====
-<<<<<<< HEAD
-Note that a Ceph pool has no size an is able to consume the space available on the OSDs where its PGs live. A Placement Group belongs to only one pool.
-=======
 A Ceph pool has no size and is able to consume the space available any OSD where its PGs are created. A Placement Group or PG belongs to only one pool.
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 ====
 
 [.lead]
@@ -1926,42 +1848,25 @@ Ceph supports two types of data protection presented in the diagram below.
 image::imgs/ceph101-dataprotection.png[Replicated Pools vs Erasure Coded Pools]
 
 Replicated pools provide better performance in almost all cases at the cost of a lower usable to raw storage ratio (1 usable byte is stored using 3 bytes of raw storage)
-<<<<<<< HEAD
-while Erasure Coding provides a cost efficient way to store data. We support the following Erasure Coding profiles with the Ceph cluster with their corresponding usable to raw ratio:
-=======
 while `Erasure Coding` provides a cost efficient way to store data with less performance. Red Hat supports the following `Erasure Coding` profiles with their corresponding usable to raw ratio:
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 * 4+2 (1:2 ratio)
 * 8+3 (1:1.375 ratio)
 * 8+4 (1:2 ratio)
 
-<<<<<<< HEAD
-Another advantage of Erasure Coding is its ability to offer extreme resilience and durability as we can configure the number of parities being used.
-=======
 Another advantage of `Erasure Coding` (EC) is its ability to offer extreme resilience and durability as we can configure the number of parities being used.
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 EC can be used for the RADOS Gateway access method and for the RBD access method (performance impact).
 
 [.lead]
 *Data Distribution*
 
 To leverage the Ceph architecture at its best, all access methods but librados, will access the data in the cluster through a collection of objects. Hence a 1GB
-<<<<<<< HEAD
-block device will be a collection of objects, each supporting a set of device sectors, a 1GB file stored in a CephFS directory will be split in multiple objects,
-a 5GB S3 object stored through the RADOS Gateway via the Multi Cloud Gateway will be divided in multiple objects.
-=======
 block device will be a collection of objects, each supporting a set of device sectors. Therefore, a 1GB file is stored in a CephFS directory will be split into multiple objects. Also a 5GB S3 object stored through the RADOS Gateway via the Multi Cloud Gateway will be divided in multiple objects.
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 .Data Distribution
 image::imgs/ceph101-rbdlayout.png[RADOS Block Device Layout]
 
 [NOTE]
 ====
-<<<<<<< HEAD
-By default, each access method uses an object size of 4MB. The above diagram details how a 32MB RBD (Block Device) data supporting a RWO PVC will be scattered throughout the cluster.
-=======
 By default, each access method uses an object size of 4MB. The above diagram details how a 32MB RBD (Block Device) supporting a RWO PVC will be scattered throughout the cluster.
->>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 ====

--- a/ocp4ocs4/ocs4.adoc
+++ b/ocp4ocs4/ocs4.adoc
@@ -420,38 +420,19 @@ sh-4.2# ceph status
 
 You can exit the toolbox by either pressing kbd:[Ctrl+D] or by executing `exit`.
 
-=== Change the default storage class to Ceph RBD
-
-After installing OCS, it is best practice to change the default *storage class* from AWS gp2 to our new OCS-backed storage class `ocs-storagecluster-ceph-rbd`.
-The easiest way to do this is using the *Openshift Web Console*. In the Console expand the `Storage` item on the left navigation bar and select `Storage Classes`.
-
-.OCP storage classes after OCS installation - AWS gp2 is the default storage class
-image::imgs/OCS-Storage-Classes-gp2-default.png[]
-
-Now click on the three dots next to the gp2 *storage class* and select `Edit Annotations`:
-
-image::imgs/OCS-edit-gp2-annotations.png[]
-
-Click on the stop sign on the right to delete the only entry, `storageclass.kubernetes.io/is-default-class`. Proceed by clicking on `Save`.
-
-Now click on the three dots next to the ocs-storagecluster-ceph-rbd *storage class* and select `Edit Annotations`
-In the new window enter `storageclass.kubernetes.io/is-default-class` as the Key and `true` as the value of the new annotation. Proceed by clicking on `Save`.
-
-Now the `ocs-storagecluster-ceph-rbd` *storage class* should be marked as default, as shown below:
-
-.After changing default storage class to Ceph RBD
-image::imgs/OCS-Storage-Classes-rbd-default.png[]
-
 == Create a new OCP application deployment using Ceph RBD volume
 
 In this section the `ocs-storagecluster-ceph-rbd` *storage class* will be used by an OCP application + database *deployment* to create RWO (ReadWriteOnce) persistent storage. The persistent storage will be a Ceph RBD (RADOS Block Device) volume (object) in the Ceph pool `ocs-storagecluster-cephblockpool`.
+
+To do so we have created a template file, based on the OpenShift rails-pgsql-persistent template, that includes an extra parameter STORAGE_CLASS that enables the end user to specify the storage class the PVC should use.
+Feel free to download `https://raw.githubusercontent.com/red-hat-storage/ocs-training/master/ocp4ocs4/configurable-rails-app.yaml` to check on the format of this template. Search for `STORAGE_CLASS` in the downloaded content.
 
 Make sure that you completed all previous sections so that you are ready to start the Rails + PostgreSQL deployment.
 
 [source,role="execute"]
 ----
 oc new-project my-database-app
-oc new-app rails-pgsql-persistent -p VOLUME_CAPACITY=5Gi
+curl https://raw.githubusercontent.com/red-hat-storage/ocs-training/master/ocp4ocs4/configurable-rails-app.yaml | oc new-app -p STORAGE_CLASS=ocs-storagecluster-ceph-rbd -p VOLUME_CAPACITY=5Gi -f -
 ----
 
 After the deployment is started you can monitor with these commands.
@@ -1669,6 +1650,12 @@ The above commands will always pull the latest noobaa version, so your version m
 ====
 
 [appendix]
+<<<<<<< HEAD
+== Ceph 101 - Introduction to Ceph
+
+This section will go through some Ceph fundamental knowledge for a better understanding of the underlying storage solution
+underneath OCS 4.
+=======
 == Introduction to Ceph
 
 This section will go through Ceph fundamental knowledge for a better understanding of the underlying storage solution
@@ -1678,17 +1665,26 @@ used by OCS 4.
 ====
 The content in this Appendix is relevant to learning about the critical components of Ceph and how Ceph works. OCS 4 uses Ceph in a prescribed manner for providing storage to OpenShift applications. Using *Operators* and *CustomResourceDefinitions* (CRDs) for deploying and managing OCS 4 may restrict some of Ceph's advanced features when compared to general use outside of OCP 4.
 ====
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 [.lead]
 *Timeline*
 
+<<<<<<< HEAD
+The Ceph project has a long history behind it and is not as young as ones may think.
+=======
 The Ceph project has a long history as you can see in the timeline below.
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 .Ceph Project History
 image::imgs/ceph101-timeline.png[Ceph Project Timeline]
 
 [.lead]
+<<<<<<< HEAD
+It is a battle-tested software defined storage solution that has been available as a storage backend with Openstack and Kubernetes for quite some time.
+=======
 It is a battle-tested software defined storage (SDS) solution that has been available as a storage backend for OpenStack and Kubernetes for quite some time.
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 [.lead]
 *Architecture*
@@ -1740,12 +1736,20 @@ are:
 .*_MDSs_*
 The Meta Data Servers manage the metadata for the POSIX compliant shared filesystem such as the directory hierarchy and the file metadata (ownership, timestamps, mode, ...).
 All the metadata is stored with RADOS and they do not server any data to the clients. MDSs are only deployed when a shared filesystem is configured in the Ceph cluster.
+<<<<<<< HEAD
+To avoid
+=======
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 If we look at the Ceph cluster foundation layer, the full picture with the different types of daemons or containers looks like this.
 
 .RADOS as it stands
 image::imgs/ceph101-rados.png[RADOS Overview]
 
+<<<<<<< HEAD
+[.lead]
+=======
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 The circle represent the MONs, the 'M' represent the MGRs and the squares with the bars represent the OSDs. In the diagram above, the cluster operates with
 3 Monitors, 2 Managers and 23 OSDs.
 
@@ -1757,7 +1761,11 @@ Ceph was designed to provides the IT environment with all the necessary access m
 .Different Storage Types Supported
 image::imgs/ceph101-differentstoragetypes.png[Ceph Access Modes]
 
+<<<<<<< HEAD
+Ceph supports block storage through the RADOS Block Device (aka RBD) access method, file storage trhough the Ceph Filesystem (aka CephFS) access method and
+=======
 Ceph supports block storage through the RADOS Block Device (aka RBD) access method, file storage through the Ceph Filesystem (aka CephFS) access method and
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 object storage through its native `librados` API or through the RADOS Gateway (aka RADOSGW or RGW) for compatibility with the S3 and Swift protocols.
 
 [.lead]
@@ -1773,12 +1781,34 @@ The Ceph native API offers different wrappers such as C, C++, Python, Java, Ruby
 [.lead]
 *RADOS Block Device (RBD)*
 
+<<<<<<< HEAD
+This access method is used in Red Hat Enterprise Linux or Openshift 3 and 4. RBDs can be accessed either through a kernel module (RHEL, OCS4)
+or through the 'librbd` API (RHOSP). In the OCP world, RBDs are designed to address the need for RWO PVCs.
+=======
 This access method is used in Red Hat Enterprise Linux or OpenShift version 3.x or 4.x. RBDs can be accessed either through a kernel module (RHEL, OCS4)
 or through the `librbd` API (RHOSP). In the OCP world, RBDs are designed to address the need for RWO PVCs.
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 [.lead]
 *_Kernel Module (kRBD)_*
 
+<<<<<<< HEAD
+.kRBD Diagram
+image::imgs/ceph101-krbd.png[Kernel based RADOS Block Device]
+
+The kernel RBD driver offers superior performance compared to the userspace `librbd` method. However, kRBD is currently limited and does
+not provide the same level of functionality. e.g. no RBD Mirroring support.
+
+[.lead]
+*_Userspace RBD (librbd)_*
+
+.librbd Diagram
+image::imgs/ceph101-librbd.png[Userspace RADOS Block Device]
+
+This access method is used in Red Hat Openstack Environment or in Openshift through the RBD-NBD driver when it lands in RHEL 8.1 kernel.
+This mode allows us to leverage all existing RBD features such as RBD Mirroring.
+
+=======
 The kernel RBD driver offers superior performance compared to the userspace `librbd` method. However, kRBD is currently limited and does
 not provide the same level of functionality. e.g., no RBD Mirroring support.
 
@@ -1794,6 +1824,7 @@ This mode allows us to leverage all existing RBD features such as RBD Mirroring.
 .librbd Diagram
 image::imgs/ceph101-librbd.png[Userspace RADOS Block Device]
 
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 [.lead]
 *_Shared Filesystem (CephFS)_*
 
@@ -1808,6 +1839,21 @@ CephFS is typically used for RWX claims but can also be used to support RWO clai
 [.lead]
 *_Object Storage, S3 and Swift (Ceph RADOS Gateway)_*
 
+<<<<<<< HEAD
+.Amazone S3 or Openstack Swift (Ceph RADOS Gateway)
+image::imgs/ceph101-rgw.png[S3 and Swift Support]
+
+This access method offers support for the Amazon S3 and Openstack Swift support on top of a Ceph cluster. The Openshift Container Storage Multi Cloud
+Gateway can leverage the RADOS Gateway to support Object Bucket Claims. From the Multi Cloud Gateway perspective the RADOS Gateway will be tagged
+as a compatible S3 endpoint.
+
+[.lead]
+*CRUSH*
+
+The Ceph cluster being a distributed architecture, some solution had to be designed to provide an efficient way to distribute the data across the multiple
+OSDs in the cluster. The technique used is called CRUSH or Controlled Replication Under Scalable Hashing. With CRUSH, every object is assigned to one
+and only one hash bucket known as a Placement Group (aka PG).
+=======
 This access method offers support for the Amazon S3 and OpenStack Swift support on top of a Ceph cluster. The Openshift Container Storage Multi Cloud
 Gateway can leverage the RADOS Gateway to support Object Bucket Claims. From the Multi Cloud Gateway perspective the RADOS Gateway will be tagged
 as a compatible S3 endpoint.
@@ -1821,19 +1867,28 @@ image::imgs/ceph101-rgw.png[S3 and Swift Support]
 The Ceph cluster being a distributed architecture some solution had to be designed to provide an efficient way to distribute the data across the multiple
 OSDs in the cluster. The technique used is called CRUSH or Controlled Replication Under Scalable Hashing. With CRUSH, every object is assigned to one
 and only one hash bucket known as a Placement Group (PG).
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 image::imgs/ceph101-crushfromobjecttoosd.png[From Object to OSD]
 
 CRUSH is the central point of configuration for the topology of the cluster. It offers a pseudo-random placement algorithm to distribute the objects across
 the PGs and uses rules to determine the mapping of the PGs to the OSDs. In essence, the PGs are an abstraction layer between the objects (application layer)
+<<<<<<< HEAD
+and the OSDs (physical layer). In case of failure, the PG will be remapped to a different physical devices (OSD) and eventually see its content resynchronized
+=======
 and the OSDs (physical layer). In case of failure, the PGs will be remapped to different physical devices (OSDs) and eventually see their content resynchronized
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 to match the protection rules  selected by the storage administrator.
 
 [.lead]
 *Cluster Partitioning*
 
 The Ceph OSDs will be in charge of the protection of the data as well as the constant checking of the integrity of the data stored in the entire cluster.
+<<<<<<< HEAD
+The cluster will be separated into logical partitions, known as a pool. Each pool has the following properties that can be adjusted:
+=======
 The cluster will be separated into logical partitions, known as pools. Each pool has the following properties that can be adjusted:
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 * An ID (immutable)
 * A name
@@ -1855,7 +1910,11 @@ The diagram above shows the relationship end to end between the object at the ac
 
 [NOTE]
 ====
+<<<<<<< HEAD
+Note that a Ceph pool has no size an is able to consume the space available on the OSDs where its PGs live. A Placement Group belongs to only one pool.
+=======
 A Ceph pool has no size and is able to consume the space available any OSD where its PGs are created. A Placement Group or PG belongs to only one pool.
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 ====
 
 [.lead]
@@ -1867,25 +1926,42 @@ Ceph supports two types of data protection presented in the diagram below.
 image::imgs/ceph101-dataprotection.png[Replicated Pools vs Erasure Coded Pools]
 
 Replicated pools provide better performance in almost all cases at the cost of a lower usable to raw storage ratio (1 usable byte is stored using 3 bytes of raw storage)
+<<<<<<< HEAD
+while Erasure Coding provides a cost efficient way to store data. We support the following Erasure Coding profiles with the Ceph cluster with their corresponding usable to raw ratio:
+=======
 while `Erasure Coding` provides a cost efficient way to store data with less performance. Red Hat supports the following `Erasure Coding` profiles with their corresponding usable to raw ratio:
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 * 4+2 (1:2 ratio)
 * 8+3 (1:1.375 ratio)
 * 8+4 (1:2 ratio)
 
+<<<<<<< HEAD
+Another advantage of Erasure Coding is its ability to offer extreme resilience and durability as we can configure the number of parities being used.
+=======
 Another advantage of `Erasure Coding` (EC) is its ability to offer extreme resilience and durability as we can configure the number of parities being used.
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 EC can be used for the RADOS Gateway access method and for the RBD access method (performance impact).
 
 [.lead]
 *Data Distribution*
 
 To leverage the Ceph architecture at its best, all access methods but librados, will access the data in the cluster through a collection of objects. Hence a 1GB
+<<<<<<< HEAD
+block device will be a collection of objects, each supporting a set of device sectors, a 1GB file stored in a CephFS directory will be split in multiple objects,
+a 5GB S3 object stored through the RADOS Gateway via the Multi Cloud Gateway will be divided in multiple objects.
+=======
 block device will be a collection of objects, each supporting a set of device sectors. Therefore, a 1GB file is stored in a CephFS directory will be split into multiple objects. Also a 5GB S3 object stored through the RADOS Gateway via the Multi Cloud Gateway will be divided in multiple objects.
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 
 .Data Distribution
 image::imgs/ceph101-rbdlayout.png[RADOS Block Device Layout]
 
 [NOTE]
 ====
+<<<<<<< HEAD
+By default, each access method uses an object size of 4MB. The above diagram details how a 32MB RBD (Block Device) data supporting a RWO PVC will be scattered throughout the cluster.
+=======
 By default, each access method uses an object size of 4MB. The above diagram details how a 32MB RBD (Block Device) supporting a RWO PVC will be scattered throughout the cluster.
+>>>>>>> 569152315c33fb2971c34942f0009b59fb7bbbed
 ====


### PR DESCRIPTION
Make the rails-pgsql example configurable to dynamically pass the requested storage class for the PVC. Also removed the storage class default change from the doc. This commit resolves #100 and resolves #111.

Not sure if I did something wrong but I see some lines from ocp4ocs4.adoc included as changed in this commit. Let me knmow if I need to redo something.