### PR TITLE
Not necessary to set TRANSFORM_EVENTS environment

### DIFF
--- a/ocs4logging/Readme.adoc
+++ b/ocs4logging/Readme.adoc
@@ -169,7 +169,6 @@ The Event Router ensures that OpenShift Events make their way into the Cluster L
 
 [source,role="execute"]
 ----
-oc set env ds/fluentd TRANSFORM_EVENTS=true -n openshift-logging
 oc process -f https://raw.githubusercontent.com/red-hat-storage/ocs-training/master/ocs4logging/event-router.yaml | oc apply -f -
 ----
 


### PR DESCRIPTION
For 4.1 [1] the env is required, but not for 4.3 anymore [2].

[1] https://docs.openshift.com/container-platform/4.1/logging/efk-logging-eventrouter.html#efk-logging-eventrouter-deploy_efk-logging-curator
[2] https://docs.openshift.com/container-platform/4.3/logging/cluster-logging-eventrouter.html