### PR TITLE
Update AMI id

### DIFF
--- a/ocp4ocs4/cluster-workerocs-us-east-2.yaml
+++ b/ocp4ocs4/cluster-workerocs-us-east-2.yaml
@@ -31,7 +31,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: ami-0eef624367320ec26
+            id: ami-04a79d8d7cfa540cc
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
           - ebs:
@@ -101,7 +101,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: ami-0eef624367320ec26
+            id: ami-04a79d8d7cfa540cc
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
           - ebs:
@@ -171,7 +171,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: ami-0eef624367320ec26
+            id: ami-04a79d8d7cfa540cc
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
           - ebs:

--- a/ocp4ocs4/cluster-workerocs-us-east-2.yaml
+++ b/ocp4ocs4/cluster-workerocs-us-east-2.yaml
@@ -31,7 +31,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: ami-04a79d8d7cfa540cc
+            id: ami-0d8f77b753c0d96dd
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
           - ebs:
@@ -101,7 +101,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: ami-04a79d8d7cfa540cc
+            id: ami-0d8f77b753c0d96dd
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
           - ebs:
@@ -171,7 +171,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: ami-04a79d8d7cfa540cc
+            id: ami-0d8f77b753c0d96dd
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
           - ebs:


### PR DESCRIPTION
New machines would not complete provisioning. New worker nodes would not get added. Edit Amazon Machine Instance identifier from providerSpec.value.ami.id: ami-0eef624367320ec26 to providerSpec.value.ami.id: ami-04a79d8d7cfa540cc .