### PR TITLE
Update ocs4-infra-nodes.adoc

### DIFF
--- a/training/modules/infra-nodes/pages/ocs4-infra-nodes.adoc
+++ b/training/modules/infra-nodes/pages/ocs4-infra-nodes.adoc
@@ -64,8 +64,8 @@ run OCS services:
       creationTimestamp: null
       labels:
         machine.openshift.io/cluster-api-cluster: kb-s25vf
-        machine.openshift.io/cluster-api-machine-role: worker
-        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
         machine.openshift.io/cluster-api-machineset: kb-s25vf-infra-us-west-2a
     spec:
       taints:


### PR DESCRIPTION
Updated to labels `machine.openshift.io/cluster-api-machine-role` and machine.openshift.io/cluster-api-machine-type` to `infra` to match OCP Infra node machineset docs.
https://docs.openshift.com/container-platform/4.6/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-aws_creating-infrastructure-machinesets