### PR TITLE
Review OCS guide

### DIFF
--- a/training/modules/ocs4/pages/ocs.adoc
+++ b/training/modules/ocs4/pages/ocs.adoc
@@ -304,7 +304,7 @@ selected.
 
 [source,role="execute"]
 ----
-oc get nodes --show-labels | grep ocs |cut -d' ' -f1
+oc get nodes --show-labels | grep ocs | cut -d ' ' -f1
 ----
 
 Then click on the button `Create` below the dialog box with the 3 workers
@@ -653,7 +653,7 @@ persistent storage on Ceph.
 
 [source,role="execute"]
 ----
-oc get route rails-pgsql-persistent -n my-database-app -o jsonpath --template="http://{.spec.host}/articles"  
+oc get route rails-pgsql-persistent -n my-database-app -o jsonpath --template="http://{.spec.host}/articles{'\n'}"
 ----
 
 This will return a route similar to this one (careful: there is no line break
@@ -783,7 +783,7 @@ just created.
 
 [source,role="execute"]
 ----
-oc rsh -n my-database-app $(oc get pods -n my-database-app|grep postgresql|grep -v deploy|awk {'print $1}')
+oc rsh -n my-database-app $(oc get pods -n my-database-app | grep postgresql | grep -v deploy | awk {'print $1}')
 ----
 [source,role="execute"]
 ----
@@ -976,7 +976,7 @@ The current allocated size for the *PVC* can be checked this way:
 
 [source,role="execute"]
 ----
-echo $(oc get pvc postgresql -n my-database-app -o jsonpath='{.status.capacity.storage}')
+oc get pvc postgresql -n my-database-app -o jsonpath='{.status.capacity.storage}{"\n"}'
 ----
 .Example output:
 ----
@@ -987,7 +987,7 @@ The requested size for the *PVC* can be checked this way:
 
 [source,role="execute"]
 ----
-echo $(oc get pvc postgresql -n my-database-app -o jsonpath='{.spec.resources.requests.storage}')
+oc get pvc postgresql -n my-database-app -o jsonpath='{.spec.resources.requests.storage}{"\n"}'
 ----
 .Example output:
 ----
@@ -1232,7 +1232,7 @@ First, find the *Route* that has been created:
 
 [source,role="execute"]
 ----
-oc get route file-uploader -n my-shared-storage -o jsonpath --template="{.spec.host}"
+oc get route file-uploader -n my-shared-storage -o jsonpath --template="{.spec.host}{'\n'}"
 ----
 
 This will return a route similar to this one (careful: there is no line break
@@ -1282,7 +1282,7 @@ Now let's verify the RWX *PVC* has been expanded.
 
 [source,role="execute"]
 ----
-echo $(oc get pvc my-shared-storage -n my-shared-storage -o jsonpath='{.spec.resources.requests.storage}')
+oc get pvc my-shared-storage -n my-shared-storage -o jsonpath='{.spec.resources.requests.storage}{"\n"}'
 ----
 .Example output:
 ----
@@ -1291,7 +1291,7 @@ echo $(oc get pvc my-shared-storage -n my-shared-storage -o jsonpath='{.spec.res
 
 [source,role="execute"]
 ----
-echo $(oc get pvc my-shared-storage -n my-shared-storage -o jsonpath='{.status.capacity.storage}')
+oc get pvc my-shared-storage -n my-shared-storage -o jsonpath='{.status.capacity.storage}{"\n"}'
 ----
 .Example output:
 ----
@@ -1934,7 +1934,7 @@ Let's scale the workerocs machinesets up with this command:
 
 [source,role="execute"]
 ----
-oc get machinesets -n openshift-machine-api -o name | grep workerocs | xargs -n1 -t oc scale -n openshift-machine-api --replicas=2
+oc get machinesets -n openshift-machine-api -o name | grep workerocs | xargs -t -n 1 oc scale -n openshift-machine-api --replicas=2
 ----
 .Example output:
 ----
@@ -2352,7 +2352,7 @@ To get the latest OpenShift CLI client run the following commands:
 [source]
 ----
 curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-mac.tar.gz | tar xzv oc
-sudo mv oc /usr/local/bin
+sudo install oc --mode 0755 --owner root --group root /usr/local/bin/oc
 ----
 
 In addition install the watch command to use with the `oc client` on your Mac using Homebrew.
@@ -2374,7 +2374,7 @@ Then reload your profile with `source $HOME/.profile`.
 [source]
 ----
 curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xzv oc
-sudo mv oc /usr/bin
+sudo install oc --mode 0755 --owner root --group root /usr/local/bin/oc
 ----
 
 Afterwards, go to your *Openshift Web Console*, log in and click on the
@@ -2428,13 +2428,15 @@ brew install noobaa/noobaa/noobaa
 .Mac steps without Homebrew
 [source]
 ----
-curl -sLO https://github.com/noobaa/noobaa-operator/releases/download/v5.6.0/noobaa-mac-v5.6.0 ; chmod +x noobaa-mac-v5.6.0 ; sudo mv noobaa-mac-v5.6.0 /usr/local/bin/noobaa
+curl -sLO https://github.com/noobaa/noobaa-operator/releases/download/v5.6.0/noobaa-mac-v5.6.0
+sudo install noobaa-mac-v5.6.0 --mode 0755 --owner root --group root /usr/local/bin/noobaa
 ----
 
 .Linux steps
 [source]
 ----
-curl -sLO https://github.com/noobaa/noobaa-operator/releases/download/v5.6.0/noobaa-linux-v5.6.0 ; chmod +x noobaa-linux-v5.6.0 ; sudo mv noobaa-linux-v5.6.0 /usr/bin/noobaa
+curl -sLO https://github.com/noobaa/noobaa-operator/releases/download/v5.6.0/noobaa-linux-v5.6.0
+sudo install noobaa-linux-v5.6.0 --mode 0755 --owner root --group root /usr/local/bin/noobaa
 ----
 
 Check that your noobaa CLI installation was successful with this command:

--- a/training/modules/ocs4/pages/ocs4-cluster-downsize.adoc
+++ b/training/modules/ocs4/pages/ocs4-cluster-downsize.adoc
@@ -28,12 +28,26 @@ These requirements need to be met before proceeding:
 
 == Procedure
 
+=== Switch to the `openshift-storage` namespace
+
+Set the current working project to `openshift-storage`. This is important since we will be managing resources in this namespace.
+
+[source,role="execute"]
+----
+oc project openshift-storage
+----
+.Example output
+----
+Now using project "openshift-storage" on server "https://api.ocp4.example.com:6443".
+----
+
 === Identify Existing storageDeviceSets
+
 As a starting point we recommend to display and keep at hand a complete list of the pods running in the `openshift-storage` namespace.
 
 [source,role="execute"]
 ----
-# oc get pods -n openshift-storage
+oc get pods -n openshift-storage
 ----
 .Running pods
 ----
@@ -85,8 +99,8 @@ Before you can downsize your cluster you need to validate how many `storageDevic
 The following command will provide you with the current number of `storageDeviceSets` configured in your cluster:
 [source,role="execute"]
 ----
-# deviceset=$(oc get storagecluster -n openshift-storage -o jsonpath='{.items[0].spec.storageDeviceSets[0].count}')
-# echo ${deviceset}
+deviceset=$(oc get storagecluster -n openshift-storage -o jsonpath='{.items[0].spec.storageDeviceSets[0].count}')
+echo ${deviceset}
 ----
 .Example output
 ----
@@ -99,15 +113,15 @@ Start a Ceph toolbox pod to verify the health of your internal Ceph cluster.
 
 [source,role="execute"]
 ----
-# oc patch OCSInitialization ocsinit -n openshift-storage --type json --patch  '[{ "op": "replace", "path": "/spec/enableCephTools", "value": true }]'
+oc patch OCSInitialization ocsinit -n openshift-storage --type json --patch  '[{ "op": "replace", "path": "/spec/enableCephTools", "value": true }]'
 ----
 
 Verify the status of your cluster.
 
 [source,role="execute"]
 ----
-# TOOLS_POD=$(oc get pods -n openshift-storage -l app=rook-ceph-tools -o name)
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
+TOOLS_POD=$(oc get pods -n openshift-storage -l app=rook-ceph-tools -o name)
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
 ----
 .Example output
 ----
@@ -120,15 +134,15 @@ HEALTH_OK
 
 [source,role="execute"]
 ----
-# oc patch storagecluster ocs-storagecluster -n openshift-storage --type json --patch '[{ "op": "replace", "path": "/spec/storageDeviceSets/0/count", "value": {n} }]'
+oc patch storagecluster ocs-storagecluster -n openshift-storage --type json --patch '[{ "op": "replace", "path": "/spec/storageDeviceSets/0/count", "value": {n} }]'
 ----
 
 **Note:** Make `{n}` as `${deviceset} - 1`. In this example `{n}` will be a value of `1`. See thee example below.
 
 [source,role="execute"]
 ----
-# newset=$((deviceset - 1))
-# oc patch storagecluster ocs-storagecluster -n openshift-storage --type json --patch "[{ "op": "replace", "path": "/spec/storageDeviceSets/0/count", "value": ${newset} }]"
+newset=$((deviceset - 1))
+oc patch storagecluster ocs-storagecluster -n openshift-storage --type json --patch "[{ "op": "replace", "path": "/spec/storageDeviceSets/0/count", "value": ${newset} }]"
 ----
 .Example output
 ----
@@ -139,7 +153,7 @@ Verify the `storagecluster` object has been updated. In the example below we go 
 
 [source,role="execute"]
 ----
-# oc get storagecluster -n openshift-storage -o jsonpath='{.items[0].spec.storageDeviceSets[0].count}'
+oc get storagecluster -n openshift-storage -o jsonpath='{.items[0].spec.storageDeviceSets[0].count}'
 ----
 .Example output
 ----
@@ -151,7 +165,7 @@ Before you can proceed you have to identify the `storageDeviceSets` that are to 
 
 [source,role="execute"]
 ----
-# oc get job.batch -n openshift-storage | grep prepare
+oc get job.batch -n openshift-storage | grep prepare
 ----
 .Example output
 ----
@@ -169,7 +183,7 @@ We recommend that you shrink your cluster by removing the higher OSD IDs that ar
 
 [source,role="execute"]
 ----
-# oc get pods -n openshift-storage | grep osd | grep -v prepare
+oc get pods -n openshift-storage | grep osd | grep -v prepare
 ----
 .Example output
 ----
@@ -185,7 +199,7 @@ In the example above, the first `storageDeviceSets` correspond to OSDs 0 through
 
 [source,role="execute"]
 ----
-# oc get pod rook-ceph-osd-5-7b4f4c6785-kgwb4 -n openshift-storage -o jsonpath="{.metadata.labels['ceph\.rook\.io\/pvc']}"
+oc get pod rook-ceph-osd-5-7b4f4c6785-kgwb4 -n openshift-storage -o jsonpath="{.metadata.labels['ceph\.rook\.io\/pvc']}"
 ----
 .Example output
 ----
@@ -208,19 +222,23 @@ You **MUST** remove each OSD, ONE AT A TIME, using the following set of commands
 
 [source,role="execute"]
 ----
-# osd_id_to_remove=5
-# oc scale deployment rook-ceph-osd-${osd_id_to_remove} --replicas=0 -n openshift-storage
+osd_id_to_remove=5
+oc scale deployment rook-ceph-osd-${osd_id_to_remove} --replicas=0 -n openshift-storage
 ----
 .Example output
 ----
 deployment.apps/rook-ceph-osd-5 scaled
 ----
 
-Verify OSD pod has been terminated.
+Verify OSD pod has been terminated. The following command should not return any pods.
 
 [source,role="execute"]
 ----
-# oc get pods -n openshift-storage | grep osd-${osd_id_to_remove}
+oc get pods -n openshift-storage -l ceph-osd-id=${osd_id_to_remove}
+----
+.Example output
+----
+No resources found in openshift-storage namespace.
 ----
 
 Once the OSD pod has been verified, you can remove the OSD from the Ceph cluster.
@@ -229,7 +247,7 @@ Once the OSD pod has been verified, you can remove the OSD from the Ceph cluster
 
 [source,role="execute"]
 ----
-# oc process -n openshift-storage ocs-osd-removal -p FAILED_OSD_ID=${osd_id_to_remove} | oc create -f -
+oc process template/ocs-osd-removal -n openshift-storage -p FAILED_OSD_IDS=${osd_id_to_remove} | oc apply -f -
 ----
 .Example output
 ----
@@ -241,8 +259,8 @@ Check cluster status and wait until the status is `HEALTH_OK`.
 
 [source,role="execute"]
 ----
-# TOOLS_POD=$(oc get pods -n openshift-storage -l app=rook-ceph-tools -o name)
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
+TOOLS_POD=$(oc get pods -n openshift-storage -l app=rook-ceph-tools -o name)
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
 ----
 .Example output
 ----
@@ -253,7 +271,7 @@ Check the number of OSDs in the Ceph cluster has decreased.
 
 [source,role="execute"]
 ----
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph osd stat
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph osd stat
 ----
 .Example output
 ----
@@ -271,8 +289,8 @@ Here are the commands for this example after the first OSD (5) is removed and pu
 
 [source,role="execute"]
 ----
-# osd_id_to_remove=4
-# oc scale deployment rook-ceph-osd-${osd_id_to_remove} --replicas=0 -n openshift-storage
+osd_id_to_remove=4
+oc scale deployment rook-ceph-osd-${osd_id_to_remove} --replicas=0 -n openshift-storage
 ----
 .Example output
 ----
@@ -281,17 +299,18 @@ deployment.apps/rook-ceph-osd-4 scaled
 
 [source,role="execute"]
 ----
-# oc get pods -n openshift-storage | grep osd-${osd_id_to_remove}
-# oc process -n openshift-storage ocs-osd-removal -p FAILED_OSD_ID=${osd_id_to_remove} | oc create -f -
+oc get pods -n openshift-storage -l ceph-osd-id=${osd_id_to_remove}
+oc process template/ocs-osd-removal -n openshift-storage -p FAILED_OSD_IDS=${osd_id_to_remove} | oc apply -f -
 ----
 .Example output
 ----
+No resources found in openshift-storage namespace.
 job.batch/ocs-osd-removal-4 created
 ----
 
 [source,role="execute"]
 ----
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
 ----
 .Example output
 ----
@@ -300,7 +319,7 @@ HEALTH_OK
 
 [source,role="execute"]
 ----
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph osd stat
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph osd stat
 ----
 .Example output
 ----
@@ -309,8 +328,8 @@ HEALTH_OK
 
 [source,role="execute"]
 ----
-# osd_id_to_remove=3
-# oc scale deployment rook-ceph-osd-${osd_id_to_remove} --replicas=0 -n openshift-storage
+osd_id_to_remove=3
+oc scale deployment rook-ceph-osd-${osd_id_to_remove} --replicas=0 -n openshift-storage
 ----
 .Example output
 ----
@@ -319,17 +338,18 @@ deployment.apps/rook-ceph-osd-3 scaled
 
 [source,role="execute"]
 ----
-# oc get pods -n openshift-storage | grep osd-${osd_id_to_remove}
-# oc process -n openshift-storage ocs-osd-removal -p FAILED_OSD_ID=${osd_id_to_remove} | oc create -f -
+oc get pods -n openshift-storage -l ceph-osd-id=${osd_id_to_remove}
+oc process template/ocs-osd-removal -n openshift-storage -p FAILED_OSD_IDS=${osd_id_to_remove} | oc apply -f -
 ----
 .Example output
 ----
+No resources found in openshift-storage namespace.
 job.batch/ocs-osd-removal-3 created
 ----
 
 [source,role="execute"]
 ----
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
 ----
 .Example output
 ----
@@ -338,7 +358,7 @@ HEALTH_WARN too many PGs per OSD (288 > max 250)
 
 [source,role="execute"]
 ----
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph osd stat
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph osd stat
 ----
 .Example output
 ----
@@ -353,7 +373,7 @@ Now that the OSDs have been removed from the Ceph cluster and the OSD pods have 
 
 [source,role="execute"]
 ----
-for i in 5 4 3; do oc delete -n openshift-storage deployment.apps/rook-ceph-osd-${i}; done
+for i in 5 4 3 ; do oc delete -n openshift-storage deployment.apps/rook-ceph-osd-${i} ; done
 ----
 .Example output
 ----
@@ -368,7 +388,7 @@ Now that the deployments have been removed we will clean up the prepare jobs tha
 
 [source,role="execute"]
 ----
-# oc get job -n openshift-storage | grep prepare
+oc get jobs -n openshift-storage -l app=rook-ceph-osd-prepare
 ----
 .Example output
 ----
@@ -384,7 +404,7 @@ Remove only the jobs corresponding to the `storageDeviceSets` we have removed.
 
 [source,role="execute"]
 ----
-# oc delete -n openshift-storage job rook-ceph-osd-prepare-ocs-deviceset-2-data-1-r7dwg
+oc delete -n openshift-storage job rook-ceph-osd-prepare-ocs-deviceset-2-data-1-r7dwg
 ----
 .Example output
 ----
@@ -393,7 +413,7 @@ job.batch "rook-ceph-osd-prepare-ocs-deviceset-2-data-1-r7dwg" deleted
 
 [source,role="execute"]
 ----
-# oc delete -n openshift-storage job rook-ceph-osd-prepare-ocs-deviceset-1-data-1-jv2qk
+oc delete -n openshift-storage job rook-ceph-osd-prepare-ocs-deviceset-1-data-1-jv2qk
 ----
 .Example output
 ----
@@ -402,7 +422,7 @@ job.batch "rook-ceph-osd-prepare-ocs-deviceset-1-data-1-jv2qk" deleted
 
 [source,role="execute"]
 ----
-# oc delete -n openshift-storage job rook-ceph-osd-prepare-ocs-deviceset-0-data-1-q72z4
+oc delete -n openshift-storage job rook-ceph-osd-prepare-ocs-deviceset-0-data-1-q72z4
 ----
 .Example output
 ----
@@ -415,7 +435,7 @@ List all PVCs created for the OSDs in the cluster.
 
 [source,role="execute"]
 ----
-# oc get pvc -n openshift-storage| grep deviceset
+oc get pvc -n openshift-storage -l ceph.rook.io/DeviceSet
 ----
 .Example output
 ----
@@ -431,7 +451,7 @@ Then delete only the PVCs corresponding to the OSDs we have removed.
 
 [source,role="execute"]
 ----
-# oc delete -n openshift-storage pvc ocs-deviceset-2-data-1-r7dwg
+oc delete -n openshift-storage pvc ocs-deviceset-2-data-1-r7dwg
 ----
 .Example output
 ----
@@ -440,7 +460,7 @@ persistentvolumeclaim "ocs-deviceset-2-data-1-r7dwg" deleted
 
 [source,role="execute"]
 ----
-# oc delete -n openshift-storage pvc ocs-deviceset-1-data-1-jv2qk
+oc delete -n openshift-storage pvc ocs-deviceset-1-data-1-jv2qk
 ----
 .Example output
 ----
@@ -449,7 +469,7 @@ persistentvolumeclaim "ocs-deviceset-1-data-1-jv2qk" deleted
 
 [source,role="execute"]
 ----
-# oc delete -n openshift-storage pvc ocs-deviceset-0-data-1-q72z4
+oc delete -n openshift-storage pvc ocs-deviceset-0-data-1-q72z4
 ----
 .Example output
 ----
@@ -461,7 +481,7 @@ Verify the physical volumes that were dynamically provisioned for the OSDs we re
 
 [source,role="execute"]
 ----
-# oc get pvc -n openshift-storage| grep deviceset
+oc get pvc -n openshift-storage -l ceph.rook.io/DeviceSet
 ----
 .Example output
 ----
@@ -472,7 +492,7 @@ ocs-deviceset-2-data-0-d6tch   Bound    pvc-f523ea66-6c0b-4c00-b618-a66129af563b
 
 [source,role="execute"]
 ----
-# oc get pv | grep deviceset | awk '{ print ($1,$2,$6,$7) }'
+oc get pv | grep deviceset | awk '{ print ($1,$2,$6,$7) }'
 ----
 .Example output
 ----
@@ -485,7 +505,7 @@ Delete the OSD removal jobs.
 
 [source,role="execute"]
 ----
-# oc get job -n openshift-storage | grep removal
+oc get job -n openshift-storage | grep removal
 ----
 .Example output
 ----
@@ -496,7 +516,7 @@ ocs-osd-removal-5                                    1/1           7s         10
 
 [source,role="execute"]
 ----
-# for i in 5 4 3; do oc delete -n openshift-storage job ocs-osd-removal-${i}; done
+for i in 5 4 3 ; do oc delete -n openshift-storage job ocs-osd-removal-${i} ; done
 ----
 .Example output
 ----
@@ -511,7 +531,7 @@ Verify no unnecessary pod was leftover (osd-prepare job, rook-ceph-osd pod, osd-
 
 [source,role="execute"]
 ----
-# oc get pods -n openshift-storage
+oc get pods -n openshift-storage
 ----
 .Example output
 ----
@@ -560,8 +580,8 @@ As an example, let's expand the same OCS cluster we just downsized to 3 OSDs and
 
 [source,role="execute"]
 ----
-# newset=2
-# oc patch storagecluster ocs-storagecluster -n openshift-storage --type json --patch "[{ "op": "replace", "path": "/spec/storageDeviceSets/0/count", "value": ${newset} }]"
+newset=2
+oc patch storagecluster ocs-storagecluster -n openshift-storage --type json --patch "[{ "op": "replace", "path": "/spec/storageDeviceSets/0/count", "value": ${newset} }]"
 ----
 .Example output
 ----
@@ -570,7 +590,7 @@ storagecluster.ocs.openshift.io/ocs-storagecluster patched
 
 [source,role="execute"]
 ----
-# oc get storagecluster -n openshift-storage -o json | jq '.items[0].spec.storageDeviceSets[0].count'
+oc get storagecluster -n openshift-storage -o json | jq '.items[0].spec.storageDeviceSets[0].count'
 ----
 .Example output
 ----
@@ -579,7 +599,7 @@ storagecluster.ocs.openshift.io/ocs-storagecluster patched
 
 [source,role="execute"]
 ----
-# oc get pods -n openshift-storage | grep osd
+oc get pods -n openshift-storage | grep osd
 ----
 .Example output
 ----
@@ -599,7 +619,7 @@ rook-ceph-osd-prepare-ocs-deviceset-2-data-1-s469h-kjgdf          0/1     Comple
 
 [source,role="execute"]
 ----
-# oc get pvc -n openshift-storage
+oc get pvc -n openshift-storage
 ----
 .Example output
 ----
@@ -618,7 +638,7 @@ rook-ceph-mon-c                Bound    pvc-b70f812e-7d02-451c-a3fb-66b438a2304b
 
 [source,role="execute"]
 ----
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph osd stat
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph osd stat
 ----
 .Example output
 ----
@@ -627,7 +647,7 @@ rook-ceph-mon-c                Bound    pvc-b70f812e-7d02-451c-a3fb-66b438a2304b
 
 [source,role="execute"]
 ----
-# oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
+oc exec -n openshift-storage ${TOOLS_POD} -- ceph health
 ----
 .Example output
 ----


### PR DESCRIPTION
- Adding project switch to `openshift-storage` at the top of `ocs-cluster-downsize`
- Adding newlines and spaces to certain commands to aid reading
- Use label selectors to get pods instead of grepping
- Use [install(1)](http://linux.die.net/man/1/install) to put `oc` and `noobaa` in `/usr/local/bin`