### PR TITLE
Parameter typo fix

### DIFF
--- a/training/modules/ocs4/pages/ocs4-cluster-downsize.adoc
+++ b/training/modules/ocs4/pages/ocs4-cluster-downsize.adoc
@@ -282,7 +282,7 @@ deployment.apps/rook-ceph-osd-4 scaled
 [source,role="execute"]
 ----
 # oc get pods -n openshift-storage | grep osd-${osd_id_to_remove}
-# oc process -n openshift-storage ocs-osd-removal -p FAILED_OSD_ID=${osd_id_to_remove} | oc create -f -
+# oc process -n openshift-storage ocs-osd-removal -p FAILED_OSD_IDS=${osd_id_to_remove} | oc create -f -
 ----
 .Example output
 ----


### PR DESCRIPTION
```
$ oc process -n openshift-storage ocs-osd-removal -p FAILED_OSD_ID=2                                               
error: unknown parameter name "FAILED_OSD_ID"
$ oc process -n openshift-storage ocs-osd-removal
error: unable to process template
  Required value: template.parameters[0]: parameter FAILED_OSD_IDS is required and must be specified
```