### PR TITLE
Update CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -42,7 +42,7 @@ To test your work locally before we deploy it to master, you can execute this co
 [source]
 ----
 # Podman
-podman run -v $PWD:/antora --rm -t antora/antora:Z --cache-dir=./.cache/antora antora-playbook-local.yml
+podman run -v $PWD:/antora:Z --rm -t antora/antora --cache-dir=./.cache/antora antora-playbook-local.yml
 # Docker
 docker run -v $PWD:/antora --rm -t antora/antora --cache-dir=./.cache/antora antora-playbook-local.yml
 ----


### PR DESCRIPTION
Very small fix to the CONTRIBUTING document.  The ":Z" is in the wrong position. In its current location, it is trying to pull an image called "antora/antora:Z". I believe the intent was to have the "Z" on the volume mount option to add the proper SELinux label to the volume mount. Tested this updated command successfully on Fedora 34 workstation box.