### PR TITLE
Add the DRCluster creation steps to the Metro DR doc

### DIFF
--- a/training/modules/ocs4/pages/odf4-metro-ramen.adoc
+++ b/training/modules/ocs4/pages/odf4-metro-ramen.adoc
@@ -437,8 +437,26 @@ image::ODR-DRPolicy-API.png[ODR Hub cluster APIs]
 .DRCluster create instance
 image::ODR-DRPolicy-create-instance.png[DRPolicy create instance]
 
-Use the following YAML to create two yaml files after replacing *<cluster>* with the correct names of your managed clusters in *ACM*. Replace *<string_value>* with any value that describes the region of these clusters. Replace the cidrs range with the one corresponding to your cluster.
+Use the following YAML to create two yaml files after replacing *<cluster>* with the correct names of your managed clusters in *ACM*. Replace *<string_value>* with any value that describes the region of these clusters.
 
+Replace the list of cidrs with the one corresponding to your cluster. The IPs in this CIDR will be the `EXTERNAL-IP` of every OpenShift node in the cluster that needs to be `fenced` from using the external `RHCS` cluster.
+
+
+Execute this command to get the IP addresses for the *managed cluster*.
+
+[source,role="execute"]
+----
+oc get nodes -o jsonpath='{range .items[*]}{.status.addresses[?(@.type=="ExternalIP")].address}{"\n"}{end}'
+----
+.Example output.
+----
+10.70.56.110
+10.70.56.111
+10.70.56.112
+10.70.56.113
+10.70.56.114
+10.70.56.115
+----
 
 NOTE: There is no need to specify a namespace to create this resource because `DRCluster` is a cluster-scoped resource.
 
@@ -454,7 +472,12 @@ spec:
   region: <string_value>
   s3ProfileName: <s3-for-cluster>
   cidrs:
-    - "192.168.40.40/24"
+    - "10.70.56.110/32"
+    - "10.70.56.111/32"
+    - "10.70.56.112/32"
+    - "10.70.56.113/32"
+    - "10.70.56.114/32"
+    - "10.70.56.115/32"
 
 
 Now create the `DRCluster` resources by copying the contents of your files into the `YAML view` (completely replacing original content). Select *Create* at the bottom of the `YAML view` screen.

--- a/training/modules/ocs4/pages/odf4-metro-ramen.adoc
+++ b/training/modules/ocs4/pages/odf4-metro-ramen.adoc
@@ -419,13 +419,64 @@ data:
 [...]    
 ----
 
+== Create the DRCluster Custom Resources on the Hub cluster
+
+ODR uses the *DRCluster* resources on the ACM hub cluster to determine the region and storage capabilities of a managed cluster.
+
+A *DRCluster* resource must have the name same as the name of the managed cluster that it refers to. It also requires a S3 profile name which is configured via the *ConfigMap* `ramen-hub-operator-config` in the `openshift-dr-system` on the *Hub cluster*.
+In the case of sync DR, specifying a region is also necessary as two DRClusters can participate in a sync DRPolicy only if they belong to the same region.
+To use the automated fencing feature, you must also specify the CIDR for the cluster. The network range specified in the CIDR will be used to automatically fence the clients from the sync storage system when the failover is performed.
+
+On the *Hub cluster* navigate to `Installed Operators` in the `openshift-dr-system` project and select `OpenShift DR Hub Operator`. You should see three available APIs, *DRCluster*, *DRPolicy* and *DRPlacementControl*.
+
+.ODR Hub cluster APIs
+image::ODR-DRPolicy-API.png[ODR Hub cluster APIs]
+
+*Create instance* for *DRCluster* and then go to *YAML view*.
+
+.DRCluster create instance
+image::ODR-DRPolicy-create-instance.png[DRPolicy create instance]
+
+Use the following YAML to create two yaml files after replacing *<cluster>* with the correct names of your managed clusters in *ACM*. Replace *<string_value>* with any value that describes the region of these clusters. Replace the cidrs range with the one corresponding to your cluster.
+
+
+NOTE: There is no need to specify a namespace to create this resource because `DRCluster` is a cluster-scoped resource.
+
+
+A sample 
+[source,yaml]
+---
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRCluster
+metadata:
+  name: <cluster>
+spec:
+  region: <string_value>
+  s3ProfileName: <s3-for-cluster>
+  cidrs:
+    - "192.168.40.40/24"
+
+
+Now create the `DRCluster` resources by copying the contents of your files into the `YAML view` (completely replacing original content). Select *Create* at the bottom of the `YAML view` screen.
+
+You can also create this resource using CLI:
+
+[source,role="execute"]
+----
+oc create -f drcluster1.yaml
+----
+.Example output.
+----
+drcluster.ramendr.openshift.io/cluster1 created
+----
+
+
 == Create DRPolicy on Hub cluster
 
-ODR uses the *DRPolicy* resources on the ACM hub cluster to deploy, failover, and relocate, workloads across managed clusters. A *DRPolicy* requires a set of two clusters.
+ODR uses the *DRPolicy* resources on the ACM hub cluster to deploy, failover, and relocate, workloads across managed clusters. A *DRPolicy* requires a set of two DRClusters.
  
-*DRPolicy* also requires that each cluster in the policy be assigned a S3 profile name, which is configured via the *ConfigMap* `ramen-hub-operator-config` in the `openshift-dr-system` on the *Hub cluster*.
 
-On the *Hub cluster* navigate to `Installed Operators` in the `openshift-dr-system` project and select `OpenShift DR Hub Operator`. You should see two available APIs, *DRPolicy* and *DRPlacementControl*.
+On the *Hub cluster* navigate to `Installed Operators` in the `openshift-dr-system` project and select `OpenShift DR Hub Operator`. You should see three available APIs, *DRCluster*,  *DRPolicy* and *DRPlacementControl*.
 
 .ODR Hub cluster APIs
 image::ODR-DRPolicy-API.png[ODR Hub cluster APIs]
@@ -435,7 +486,7 @@ image::ODR-DRPolicy-API.png[ODR Hub cluster APIs]
 .DRPolicy create instance
 image::ODR-DRPolicy-create-instance.png[DRPolicy create instance]
 
-Save the following YAML to filename drpolicy.yaml after replacing *<cluster1>* and *<cluster2>* with the correct names of your managed clusters in *ACM*. Replace *<string_value>* with any value (i.e. metro).
+Save the following YAML to filename drpolicy.yaml after replacing *<cluster1>* and *<cluster2>* with the correct names of your DRCluster CRs.
 
 NOTE: There is no need to specify a namespace to create this resource because `DRPolicy` is a cluster-scoped resource.
 
@@ -446,15 +497,9 @@ kind: DRPolicy
 metadata:
   name: odr-policy
 spec:
-  drClusterSet:
-  - name: <cluster1>
-    region: <string_value>
-    s3ProfileName: s3-primary
-    clusterFence: Unfenced
-  - name: <cluster2>
-    region: <string_value>
-    s3ProfileName: s3-secondary
-    clusterFence: Unfenced
+  drClusters:
+    - <cluster1>
+    - <cluster2>
 ----    
 
 Now create the `DRPolicy` resource by copying the contents of your unique `drpolicy.yaml` file into the `YAML view` (completely replacing original content). Select *Create* at the bottom of the `YAML view` screen.


### PR DESCRIPTION
This commit adds a new chapter that introduces the DRCluster CRD and its creation process.
We also change the content for the DRPolicy creation as the updates to the CRD.