### PR TITLE
rm featuregates section from 4.10 and add to 4.11

### DIFF
--- a/training/modules/ocs4/pages/odf410-multisite-ramen.adoc
+++ b/training/modules/ocs4/pages/odf410-multisite-ramen.adoc
@@ -581,14 +581,6 @@ oc patch proxy cluster --type=merge  --patch='{"spec":{"trustedCA":{"name":"user
 ----
 proxy.config.openshift.io/cluster patched
 ----
-== Enable FeatureGates
-
-Logging in to both managed clusters on the same browser is pre-req. Also enable *FeatureGates*. There are two ways to enable FeatureGates. One using CLI and the other using web console. Refer below document links on how to proceed  
-
-*Enable Using Web Console* https://github.com/red-hat-storage/ocs-training/blob/master/training/modules/ocs4/pages/odf4-metro-ramen.adoc#11-create-s3-secrets-on-managed-clusters
-
-*Enable Using CLI* https://github.com/red-hat-storage/ocs-training/blob/master/training/modules/ocs4/pages/odf4-metro-ramen.adoc#11-create-s3-secrets-on-managed-clusters
-
 
 == Create DRPolicy on Hub cluster
 

--- a/training/modules/ocs4/pages/odf411-metro-ramen.adoc
+++ b/training/modules/ocs4/pages/odf411-metro-ramen.adoc
@@ -323,6 +323,13 @@ oc patch proxy cluster --type=merge  --patch='{"spec":{"trustedCA":{"name":"user
 proxy.config.openshift.io/cluster patched
 ----
 
+== Enable FeatureGates
+
+Logging in to both managed clusters on the same browser is pre-req. Also enable *FeatureGates*. There are two ways to enable FeatureGates. One using CLI and the other using web console. Refer below document links on how to proceed  
+
+*Enable Using Web Console* https://docs.openshift.com/container-platform/4.10/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-console_nodes-cluster-enabling
+
+*Enable Using CLI* https://docs.openshift.com/container-platform/4.10/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-cli_nodes-cluster-enabling
 
 == Create DataPolicy on Hub cluster
 


### PR DESCRIPTION
enabling featuregates section was incorrectly added to metro-dr 4.10 doc. 
This should ideally be present in 4.11 doc and also featuregates doc link was incorrect.  

Signed-off-by: rakeshgm <rakeshgm@redhat.com>