### PR TITLE
change failureDomain of ObjectStore to host

### DIFF
--- a/training/modules/ocs4/pages/ocs4-enable-rgw.adoc
+++ b/training/modules/ocs4/pages/ocs4-enable-rgw.adoc
@@ -45,7 +45,7 @@ spec:
       algorithm: ""
       codingChunks: 0
       dataChunks: 0
-    failureDomain: zone
+    failureDomain: host
     replicated:
       size: 3
   gateway:
@@ -91,7 +91,7 @@ spec:
       algorithm: ""
       codingChunks: 0
       dataChunks: 0
-    failureDomain: zone
+    failureDomain: host
     replicated:
       size: 3
 ----


### PR DESCRIPTION
The failureDomain settings for the ObjectStore CR used to deploy the RGW were set on `zone`. This worked for a multi-zone deployment, as it was defined in earlier versions of RHPDS deployments of OpenShift.
For some time now, default RHPDS deployments of OpenShift are done in a single zone, which breaks RGW deployment with example file.
This PR sets failureDomain to `host` to make it compatible again. In some cases it may not be the best setting, but at least it would always work.